### PR TITLE
Поправил подключение

### DIFF
--- a/src/StompClient.php
+++ b/src/StompClient.php
@@ -312,15 +312,21 @@ class StompClient
     /**
      * Подключение к брокеру по ссылке.
      *
-     * @param  string     $url
-     * @param  string     $login
-     * @param  string     $pw
+     * @param  string $url
+     * @param  string $login
+     * @param  string $pw
+     *
      * @return Stomp|null
+     * @throws Exception
      */
     private function connect($url, $login, $pw)
     {
         try {
-            return new Stomp($url, $login, $pw, ['accept-version' => '1.2', 'RECEIPT' => true]);
+            return new Stomp($url, $login, $pw, [
+                'accept-version' => '1.2',
+                'RECEIPT' => true,
+                'host' => $login
+            ]);
         } catch (StompException $e) {
             throw $e;
         }

--- a/src/StompClient.php
+++ b/src/StompClient.php
@@ -317,6 +317,7 @@ class StompClient
      * @param  string $pw
      *
      * @return Stomp|null
+     *
      * @throws Exception
      */
     private function connect($url, $login, $pw)

--- a/src/StompClient.php
+++ b/src/StompClient.php
@@ -312,9 +312,9 @@ class StompClient
     /**
      * Подключение к брокеру по ссылке.
      *
-     * @param  string $url
-     * @param  string $login
-     * @param  string $pw
+     * @param string $url
+     * @param string $login
+     * @param string $pw
      *
      * @return Stomp|null
      *


### PR DESCRIPTION
В некоторых случаях при работе с rabbitMQ необходим заголовок host с указанием наименования системы